### PR TITLE
docs: add api url env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_URL=http://localhost:3333

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -34,3 +34,20 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Environment Variables
+
+Create a `.env` file based on the provided `.env.example` and set the required variable:
+
+```
+NEXT_PUBLIC_API_URL=http://localhost:3333
+```
+
+For development, copy the example file:
+
+```bash
+cp .env.example .env
+```
+
+Ensure the `NEXT_PUBLIC_API_URL` value matches your API endpoint. In production, add the same variable in your Vercel project settings.
+


### PR DESCRIPTION
## Summary
- add `.env.example` with `NEXT_PUBLIC_API_URL`
- document environment variable usage in README
- allow committing `.env.example`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_689e18dc3d0c8325b02e631dbf39dae5